### PR TITLE
Added an option to skip SSL check in webook

### DIFF
--- a/nodes/webhook.py
+++ b/nodes/webhook.py
@@ -11,6 +11,7 @@ class Webhook:
                 "any": (ComfyAnyType("*"), {}),
                 # "mode": (["always", "on empty queue"], {}), # TODO: Need a way to get queue status from main.py
                 "webhook_url": ("STRING", {'default': 'http://localhost:5000/'}),
+                "verify_ssl": ("BOOLEAN", {"default": True}),
                 "notification_text": ('STRING', {'default': 'Your notification has triggered.'}),
                 "json_format": ('STRING', {'default': '{"text": "<notification_text>"}'}),
                 "timeout": ('FLOAT', {'default': 3, 'min': 0, 'max': 60}),
@@ -22,9 +23,10 @@ class Webhook:
     RETURN_TYPES = tuple()
     CATEGORY = "notifications"
 
-    def hook(self, any, webhook_url, notification_text, json_format, timeout):
+    def hook(self, any, webhook_url, notification_text, json_format, timeout, verify_ssl):
+
         payload = json_format.replace("<notification_text>", notification_text)
         payload = json.loads(payload)
-        res = requests.post(webhook_url, json=payload, timeout=timeout)
+        res = requests.post(webhook_url, json=payload, timeout=timeout, verify=verify_ssl)
         res.raise_for_status()
         return (0, )


### PR DESCRIPTION
Was using the Webhook node to integrate with my local instance of HomeAssistant and realised that it would fail because it of SSL check. Added a simple value to toggle it on/off - defaults to on